### PR TITLE
Fix PrintInputHelp and add test

### DIFF
--- a/cmd/icaltrace/input.go
+++ b/cmd/icaltrace/input.go
@@ -37,8 +37,7 @@ func InputHandler(inputType string, inputFile string) (pimtrace.Data, error) {
 
 func PrintInputHelp() {
 	fmt.Println("input-types available: ")
-	fmt.Printf(" %-30s %s\n", "mailfile", "A single mail file")
-	fmt.Printf(" %-30s %s\n", "mbox", "Mbox file")
+	fmt.Printf(" %-30s %s\n", "ical", "Read an iCal file or '-' for stdin")
 	fmt.Printf(" %-30s %s\n", "list", "This help text")
 	fmt.Println()
 }

--- a/cmd/icaltrace/input_test.go
+++ b/cmd/icaltrace/input_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureOutput(f func()) string {
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+	return buf.String()
+}
+
+func TestPrintInputHelpContainsIcal(t *testing.T) {
+	out := captureOutput(PrintInputHelp)
+	if !strings.Contains(out, "ical") {
+		t.Errorf("expected help to contain 'ical' but got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- show proper iCal input types in `PrintInputHelp`
- test that the help text mentions `ical`

## Testing
- `go test ./cmd/icaltrace -run TestPrintInputHelpContainsIcal -v`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68457ec1c29c832f815e4d011ce832d5