### PR TITLE
Update GitHub Actions cache

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache-Go
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod              # Module download cache

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -18,7 +18,7 @@ jobs:
                 with:
                     go-version: 1.19
             -   name: Cache-Go
-                uses: actions/cache@v1
+                uses: actions/cache@v3
                 with:
                     path: |
                         ~/go/pkg/mod              # Module download cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Cache-Go
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: |
           ~/go/pkg/mod              # Module download cache


### PR DESCRIPTION
## Summary
- update deprecated `actions/cache@v1` to `v3`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6846decf1894832faab7720752e905c1