### PR TITLE
Fix unchecked error in tests

### DIFF
--- a/cmd/icaltrace/input_test.go
+++ b/cmd/icaltrace/input_test.go
@@ -16,7 +16,9 @@ func captureOutput(f func()) string {
 	w.Close()
 	os.Stdout = old
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	if _, err := io.Copy(&buf, r); err != nil {
+		panic(err)
+	}
 	r.Close()
 	return buf.String()
 }


### PR DESCRIPTION
## Summary
- ensure `io.Copy` error is checked in `captureOutput`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854de346cf0832fb629d3eec9775bbe