### PR TITLE
Fix error handling in io.Copy

### DIFF
--- a/cmd/icaltrace/input_test.go
+++ b/cmd/icaltrace/input_test.go
@@ -16,7 +16,9 @@ func captureOutput(f func()) string {
 	w.Close()
 	os.Stdout = old
 	var buf bytes.Buffer
-	io.Copy(&buf, r)
+	if _, err := io.Copy(&buf, r); err != nil {
+		panic(err)
+	}
 	r.Close()
 	return buf.String()
 }


### PR DESCRIPTION
## Summary
- check and handle the error returned by `io.Copy` in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854dd2b89f8832fa883ddd48d546ed9