### PR TITLE
Fix silently ignored errors and failure to close files properly

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -379,9 +379,15 @@ func (s *SortTransformerSorter) Less(i, j int) bool {
 		if err != nil {
 			log.Printf("Sort execution error for element i: %v", err)
 		}
+		if iv == nil {
+			iv = &pimtrace.SimpleNilValue{}
+		}
 		jv, err := e.Execute(jo, s.Context)
 		if err != nil {
 			log.Printf("Sort execution error for element j: %v", err)
+		}
+		if jv == nil {
+			jv = &pimtrace.SimpleNilValue{}
 		}
 		if iv.Equal(jv) {
 			continue

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"fmt"
+	"log"
 	"pimtrace"
 	"pimtrace/dataformats/groupdata"
 	"pimtrace/dataformats/tabledata"
@@ -374,8 +375,14 @@ func (s *SortTransformerSorter) Len() int {
 func (s *SortTransformerSorter) Less(i, j int) bool {
 	for _, e := range s.SortTransformer.Expression {
 		io, jo := s.Data.Entry(i), s.Data.Entry(j)
-		iv, _ := e.Execute(io, s.Context)
-		jv, _ := e.Execute(jo, s.Context)
+		iv, err := e.Execute(io, s.Context)
+		if err != nil {
+			log.Printf("Sort execution error for element i: %v", err)
+		}
+		jv, err := e.Execute(jo, s.Context)
+		if err != nil {
+			log.Printf("Sort execution error for element j: %v", err)
+		}
 		if iv.Equal(jv) {
 			continue
 		}

--- a/dataformats/maildata/data.go
+++ b/dataformats/maildata/data.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"github.com/emersion/go-message/mail"
 	"io"
 	"mime/multipart"
@@ -119,7 +120,10 @@ func (s *MailWithSource) From() string {
 }
 
 func (s *MailWithSource) Time() time.Time {
-	d, _ := s.MailHeader.Date()
+	d, err := s.MailHeader.Date()
+	if err != nil {
+		log.Printf("Error parsing mail date: %v", err)
+	}
 	return d
 }
 

--- a/dataformats/maildata/input.go
+++ b/dataformats/maildata/input.go
@@ -12,12 +12,16 @@ import (
 	"pimtrace/dataformats"
 )
 
-func ReadMBoxStream(f io.Reader, fType string, fName string, ops ...any) ([]*MailWithSource, error) {
+func ReadMBoxStream(f io.Reader, fType string, fName string, ops ...any) (res []*MailWithSource, err error) {
 	ff, closers, err := dataformats.ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
 		for _, fc := range closers {
-			if err := fc.Close(); err != nil {
-				log.Printf("error closing ReaderStreamMapper: %s", err)
+			if cerr := fc.Close(); cerr != nil {
+				if err == nil {
+					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)
+				} else {
+					log.Printf("error closing ReaderStreamMapper: %s", cerr)
+				}
 			}
 		}
 	}()
@@ -27,28 +31,32 @@ func ReadMBoxStream(f io.Reader, fType string, fName string, ops ...any) ([]*Mai
 	mbr := mbox.NewReader(ff)
 	var ms []*MailWithSource
 	for {
-		mr, err := mbr.NextMessage()
-		if err != nil && !errors.Is(err, io.EOF) {
-			return nil, fmt.Errorf("reading message %d from Mbox %s: %w", len(ms)+1, fName, err)
+		mr, nextErr := mbr.NextMessage()
+		if nextErr != nil && !errors.Is(nextErr, io.EOF) {
+			return nil, fmt.Errorf("reading message %d from Mbox %s: %w", len(ms)+1, fName, nextErr)
 		}
 		if mr == nil {
 			return ms, nil
 		}
-		mrms, err := ReadMailStream(mr, fType, fName)
-		if err != nil {
-			log.Printf("parsing message %d from Mbox %s: %v", len(ms)+1, fName, err)
+		mrms, readErr := ReadMailStream(mr, fType, fName)
+		if readErr != nil {
+			log.Printf("parsing message %d from Mbox %s: %v", len(ms)+1, fName, readErr)
 			continue
 		}
 		ms = append(ms, mrms...)
 	}
 }
 
-func ReadMailStream(f io.Reader, fType string, fName string, ops ...any) ([]*MailWithSource, error) {
+func ReadMailStream(f io.Reader, fType string, fName string, ops ...any) (res []*MailWithSource, err error) {
 	ff, closers, err := dataformats.ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
 		for _, fc := range closers {
-			if err := fc.Close(); err != nil {
-				log.Printf("error closing ReaderStreamMapper: %s", err)
+			if cerr := fc.Close(); cerr != nil {
+				if err == nil {
+					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)
+				} else {
+					log.Printf("error closing ReaderStreamMapper: %s", cerr)
+				}
 			}
 		}
 	}()

--- a/dataformats/maildata/input.go
+++ b/dataformats/maildata/input.go
@@ -15,7 +15,8 @@ import (
 func ReadMBoxStream(f io.Reader, fType string, fName string, ops ...any) (res []*MailWithSource, err error) {
 	ff, closers, err := dataformats.ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
-		for _, fc := range closers {
+		for i := range closers {
+			fc := closers[len(closers)-i-1]
 			if cerr := fc.Close(); cerr != nil {
 				if err == nil {
 					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)
@@ -50,7 +51,8 @@ func ReadMBoxStream(f io.Reader, fType string, fName string, ops ...any) (res []
 func ReadMailStream(f io.Reader, fType string, fName string, ops ...any) (res []*MailWithSource, err error) {
 	ff, closers, err := dataformats.ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
-		for _, fc := range closers {
+		for i := range closers {
+			fc := closers[len(closers)-i-1]
 			if cerr := fc.Close(); cerr != nil {
 				if err == nil {
 					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)

--- a/dataformats/next.go
+++ b/dataformats/next.go
@@ -9,22 +9,30 @@ import (
 
 type Next[T any] func(f io.Reader, fType string, fName string, ops ...any) ([]T, error)
 
-func ReadFile[T any](fType string, fName string, next Next[T], ops ...any) ([]T, error) {
+func ReadFile[T any](fType string, fName string, next Next[T], ops ...any) (res []T, err error) {
 	f, err := os.OpenFile(fName, os.O_RDONLY, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s %s: %w", fType, fName, err)
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
-			log.Printf("Error closing file: %s: %s", fName, err)
+		if cerr := f.Close(); cerr != nil {
+			if err == nil {
+				err = fmt.Errorf("closing file %s: %w", fName, cerr)
+			} else {
+				log.Printf("Error closing file: %s: %s", fName, cerr)
+			}
 		}
 	}()
 	ff, closers, err := ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
 		for i := range closers {
 			fc := closers[len(closers)-i-1]
-			if err := fc.Close(); err != nil {
-				log.Printf("error closing ReaderStreamMapper: %s", err)
+			if cerr := fc.Close(); cerr != nil {
+				if err == nil {
+					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)
+				} else {
+					log.Printf("error closing ReaderStreamMapper: %s", cerr)
+				}
 			}
 		}
 	}()

--- a/dataformats/tar.go
+++ b/dataformats/tar.go
@@ -10,21 +10,29 @@ import (
 	"path/filepath"
 )
 
-func ReadTarFile[T any](fType string, fName string, next Next[T], globs []string, ops ...any) ([]T, error) {
+func ReadTarFile[T any](fType string, fName string, next Next[T], globs []string, ops ...any) (res []T, err error) {
 	f, err := os.OpenFile(fName, os.O_RDONLY, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("reading Mbox %s: %w", fName, err)
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
-			log.Printf("Error closing file: %s: %s", fName, err)
+		if cerr := f.Close(); cerr != nil {
+			if err == nil {
+				err = fmt.Errorf("closing file %s: %w", fName, cerr)
+			} else {
+				log.Printf("Error closing file: %s: %s", fName, cerr)
+			}
 		}
 	}()
 	ff, closers, err := ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
 		for _, fc := range closers {
-			if err := fc.Close(); err != nil {
-				log.Printf("error closing ReaderStreamMapper: %s", err)
+			if cerr := fc.Close(); cerr != nil {
+				if err == nil {
+					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)
+				} else {
+					log.Printf("error closing ReaderStreamMapper: %s", cerr)
+				}
 			}
 		}
 	}()
@@ -34,12 +42,16 @@ func ReadTarFile[T any](fType string, fName string, next Next[T], globs []string
 	return ReadTarStream(ff, fType, fName, next, globs)
 }
 
-func ReadTarStream[T any](f io.Reader, fType string, fName string, next Next[T], globs []string, ops ...any) ([]T, error) {
+func ReadTarStream[T any](f io.Reader, fType string, fName string, next Next[T], globs []string, ops ...any) (res []T, err error) {
 	ff, closers, err := ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
 		for _, fc := range closers {
-			if err := fc.Close(); err != nil {
-				log.Printf("error closing ReaderStreamMapper: %s", err)
+			if cerr := fc.Close(); cerr != nil {
+				if err == nil {
+					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)
+				} else {
+					log.Printf("error closing ReaderStreamMapper: %s", cerr)
+				}
 			}
 		}
 	}()

--- a/dataformats/tar.go
+++ b/dataformats/tar.go
@@ -26,7 +26,8 @@ func ReadTarFile[T any](fType string, fName string, next Next[T], globs []string
 	}()
 	ff, closers, err := ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
-		for _, fc := range closers {
+		for i := range closers {
+			fc := closers[len(closers)-i-1]
 			if cerr := fc.Close(); cerr != nil {
 				if err == nil {
 					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)
@@ -45,7 +46,8 @@ func ReadTarFile[T any](fType string, fName string, next Next[T], globs []string
 func ReadTarStream[T any](f io.Reader, fType string, fName string, next Next[T], globs []string, ops ...any) (res []T, err error) {
 	ff, closers, err := ReaderStreamMapperOptionProcessor(f, ops)
 	defer func() {
-		for _, fc := range closers {
+		for i := range closers {
+			fc := closers[len(closers)-i-1]
 			if cerr := fc.Close(); cerr != nil {
 				if err == nil {
 					err = fmt.Errorf("closing ReaderStreamMapper: %w", cerr)

--- a/funcs/as.go
+++ b/funcs/as.go
@@ -3,6 +3,7 @@ package funcs
 import (
 	"errors"
 	"fmt"
+	"log"
 	"pimtrace"
 	"pimtrace/dataformats/nildata"
 
@@ -35,7 +36,13 @@ func (c As[T]) ColumnName(args []T) string {
 	if len(args) < 2 {
 		return ""
 	}
-	v, _ := args[1].Execute(&nildata.Row{}, nil)
+	v, err := args[1].Execute(&nildata.Row{}, nil)
+	if err != nil {
+		log.Printf("Error executing as argument: %v", err)
+	}
+	if v == nil {
+		return ""
+	}
 	return v.String()
 }
 

--- a/util.go
+++ b/util.go
@@ -12,28 +12,35 @@ type HasStringArray interface {
 	HeadersStringArray() []string
 }
 
-func WriteFileWrapper(fType string, fName string, fun func(f io.Writer, fName string) error) error {
+func WriteFileWrapper(fType string, fName string, fun func(f io.Writer, fName string) error) (err error) {
 	f, err := os.OpenFile(fName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("creating %s %s: %w", fType, fName, err)
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
-			log.Printf("Error closing %s file: %s: %s", fType, fName, err)
+		if cerr := f.Close(); cerr != nil {
+			if err == nil {
+				err = fmt.Errorf("closing %s file %s: %w", fType, fName, cerr)
+			} else {
+				log.Printf("Error closing %s file: %s: %s", fType, fName, cerr)
+			}
 		}
 	}()
 	return fun(f, fName)
 }
 
-func ReadFileWrapper[T Data](fType string, fName string, fun func(f io.Reader, fName string) (T, error)) (T, error) {
-	var result T
+func ReadFileWrapper[T Data](fType string, fName string, fun func(f io.Reader, fName string) (T, error)) (result T, err error) {
 	f, err := os.OpenFile(fName, os.O_RDONLY, 0644)
 	if err != nil {
 		return result, fmt.Errorf("reading %s %s: %w", fType, fName, err)
 	}
 	defer func() {
-		if err := f.Close(); err != nil {
-			log.Printf("Error closing %s file: %s: %s", fType, fName, err)
+		if cerr := f.Close(); cerr != nil {
+			if err == nil {
+				err = fmt.Errorf("closing %s file %s: %w", fType, fName, cerr)
+			} else {
+				log.Printf("Error closing %s file: %s: %s", fType, fName, cerr)
+			}
 		}
 	}()
 	return fun(f, fName)


### PR DESCRIPTION
This PR fixes silently ignored errors that were dropped using blank identifiers (`_`), notably for `Close()` calls in `defer` statements. It uses Go's idiomatic named return values (`err error`) to correctly bubble up file closing errors while ensuring that primary execution errors are not masked. It also updates internal utility functions (e.g., `ReadFileWrapper`, `WriteFileWrapper`, `ReadTarStream`, `ReadMBoxStream`) and logic files (`ast.go`, `data.go`, `as.go`) to log or return explicit errors when executing operations like sorting, date parsing, or stream mapping.

**Changes:**
1. **util.go, next.go, tar.go, input.go:** Updated wrappers and read/write stream mappers to bubble up deferred file `Close()` errors using named return values.
2. **ast/ast.go:** Added error handling for element execution inside `SortTransformerSorter.Less`.
3. **funcs/as.go:** Handled `Execute()` errors for elements and guarded against `nil` execution values prior to invoking `.String()`.
4. **dataformats/maildata/data.go:** Handled `Date()` parsing errors gracefully inside `Time()` fallback logic using `log.Printf`.
5. **Testing & Code Safety:** Verified no unexpected behavioral modifications with successful `go test ./...` coverage, and used `errcheck` to ensure no meaningful business-level `Close()` dropping remains.

---
*PR created automatically by Jules for task [11839834070968955401](https://jules.google.com/task/11839834070968955401) started by @arran4*