### PR TITLE
Fix errcheck linter warnings by explicitly ignoring unhandled returns

### DIFF
--- a/cmd/csvtrace/main.go
+++ b/cmd/csvtrace/main.go
@@ -33,13 +33,13 @@ func main() {
 		helpFlag    = f.Bool("help", false, "Prints help")
 	)
 	f.Usage = func() {
-		fmt.Println("Usage: ", os.Args[0], "[Flags]", "[Query]")
+		_, _ = fmt.Println("Usage: ", os.Args[0], "[Flags]", "[Query]")
 		f.PrintDefaults()
 		PrintQueryHelp(os.Stdout, *parser)
 	}
 
 	if *versionFlag {
-		fmt.Println(version, commit, date)
+		_, _ = fmt.Println(version, commit, date)
 		return
 	}
 
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	if *helpFlag || len(os.Args) <= 1 {
-		fmt.Println("No query found")
+		_, _ = fmt.Println("No query found")
 		f.Usage()
 		os.Exit(-1)
 	}

--- a/cmd/icaltrace/main.go
+++ b/cmd/icaltrace/main.go
@@ -32,13 +32,13 @@ func main() {
 		helpFlag    = f.Bool("help", false, "Prints help")
 	)
 	f.Usage = func() {
-		fmt.Println("Usage: ", os.Args[0], "[Flags]", "[Query]")
+		_, _ = fmt.Println("Usage: ", os.Args[0], "[Flags]", "[Query]")
 		f.PrintDefaults()
 		PrintQueryHelp(os.Stdout, *parser)
 	}
 
 	if *versionFlag {
-		fmt.Println(version, commit, date)
+		_, _ = fmt.Println(version, commit, date)
 		return
 	}
 
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	if *helpFlag || len(os.Args) <= 1 {
-		fmt.Println("No query found")
+		_, _ = fmt.Println("No query found")
 		f.Usage()
 		os.Exit(-1)
 	}

--- a/cmd/mailtrace/main.go
+++ b/cmd/mailtrace/main.go
@@ -33,13 +33,13 @@ func main() {
 		helpFlag    = f.Bool("help", false, "Prints help")
 	)
 	f.Usage = func() {
-		fmt.Println("Usage: ", os.Args[0], "[Flags]", "[Query]")
+		_, _ = fmt.Println("Usage: ", os.Args[0], "[Flags]", "[Query]")
 		f.PrintDefaults()
 		PrintQueryHelp(os.Stdout, *parser)
 	}
 
 	if *versionFlag {
-		fmt.Println(version, commit, date)
+		_, _ = fmt.Println(version, commit, date)
 		return
 	}
 
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	if *helpFlag || len(os.Args) <= 1 {
-		fmt.Println("No query found")
+		_, _ = fmt.Println("No query found")
 		f.Usage()
 		os.Exit(-1)
 	}

--- a/dataformats/output.go
+++ b/dataformats/output.go
@@ -33,7 +33,7 @@ func OutputHandler(p pimtrace.Data, mode, outputPath string, customOutputs [][2]
 			return fmt.Errorf("unsupported format: %s of %s", mode, reflect.TypeOf(p))
 		}
 	case "count":
-		fmt.Println(p.Len())
+		_, _ = fmt.Println(p.Len())
 		return nil
 	case "list":
 		PrintOutputHelp(customOutputs)
@@ -49,7 +49,7 @@ func OutputHandler(p pimtrace.Data, mode, outputPath string, customOutputs [][2]
 }
 
 func PrintOutputHelp(custom [][2]string) {
-	fmt.Println("--output-types: ")
+	_, _ = fmt.Println("--output-types: ")
 	each := [][2]string{
 		{"list", "This help text"},
 		{"csv", "Data in csv format"},
@@ -58,7 +58,7 @@ func PrintOutputHelp(custom [][2]string) {
 		{"plot.bar", "Writes a plot of the data out, the data must be tabular and columns must be in the form of: string, number*"},
 	}
 	for _, e := range append(each, custom...) {
-		fmt.Printf(" %-30s %s\n", e[0], e[1])
+		_, _ = fmt.Printf(" %-30s %s\n", e[0], e[1])
 	}
-	fmt.Println()
+	_, _ = fmt.Println()
 }

--- a/funcs/util.go
+++ b/funcs/util.go
@@ -6,7 +6,7 @@ import (
 )
 
 func PrintFunctionList() {
-	fmt.Println("Functions: ")
+	_, _ = fmt.Println("Functions: ")
 	for _, f := range Functions[ValueExpression]() {
 		for _, af := range f.Arguments() {
 			args := make([]string, 0, len(af.Args))
@@ -14,7 +14,7 @@ func PrintFunctionList() {
 				args = append(args, aff.String())
 			}
 			fn := fmt.Sprintf("f.%s[%s]", f.Name(), strings.Join(args, ","))
-			fmt.Printf("%-40s%40s\n", fn, af.Description)
+			_, _ = fmt.Printf("%-40s%40s\n", fn, af.Description)
 		}
 	}
 }


### PR DESCRIPTION
Fixes errcheck linter warnings.

---
*PR created automatically by Jules for task [10906153658829216825](https://jules.google.com/task/10906153658829216825) started by @arran4*